### PR TITLE
Fix broken json schema option

### DIFF
--- a/src/main/java/nl/dannyj/mistral/models/completion/tool/JsonSchema.java
+++ b/src/main/java/nl/dannyj/mistral/models/completion/tool/JsonSchema.java
@@ -17,6 +17,7 @@
 package nl.dannyj.mistral.models.completion.tool;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,6 +61,7 @@ public class JsonSchema {
      * @return The string representing the JSON schema.
      */
     @NotNull
+    @JsonRawValue
     @JsonProperty("schema")
     private String schema;
 
@@ -71,4 +73,7 @@ public class JsonSchema {
      */
     @Builder.Default
     private boolean strict = false;
+
+
+
 }


### PR DESCRIPTION
Mistral expects a json object for the schema field but was provided a string encoding the json object.
Fixed by telling jackson to treat the string as raw json
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON schema handling in `JsonSchema` by adding `@JsonRawValue` to treat `schema` as raw JSON.
> 
>   - **Behavior**:
>     - Fixes JSON schema handling in `JsonSchema` class by adding `@JsonRawValue` to `schema` field.
>     - Ensures `schema` is treated as raw JSON, aligning with Mistral's expectations.
>   - **Annotations**:
>     - Adds `@JsonRawValue` to `schema` field in `JsonSchema` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Dannyj1%2Fmistral-java-client&utm_source=github&utm_medium=referral)<sup> for 79804a0bcecbb79f9ac512b5f3e6bb1e162fe530. You can [customize](https://app.ellipsis.dev/Dannyj1/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->